### PR TITLE
fix: Linux gamepad triggers use wrong ABS axis codes (ABS_HAT2X/Y → ABS_Z/ABS_RZ)

### DIFF
--- a/src/simulation/linux/gamepadSim.cpp
+++ b/src/simulation/linux/gamepadSim.cpp
@@ -97,8 +97,8 @@ GamepadInjector::GamepadInjector()
 	absinfo.maximum = 255;
 	absinfo.fuzz = 0;
 	absinfo.flat = 0;
-	libevdev_enable_event_code(dev.get(), EV_ABS, ABS_HAT2X, &absinfo); // Left trigger
-	libevdev_enable_event_code(dev.get(), EV_ABS, ABS_HAT2Y, &absinfo); // Right trigger
+	libevdev_enable_event_code(dev.get(), EV_ABS, ABS_Z, &absinfo);  // Left trigger
+	libevdev_enable_event_code(dev.get(), EV_ABS, ABS_RZ, &absinfo); // Right trigger
 
 	// Create uinput device
 	libevdev_uinput *rawUidev;
@@ -148,8 +148,8 @@ void GamepadInjector::setTriggers(float leftTrigger, float rightTrigger)
 	int leftInt = static_cast<int>(leftTrigger * 255);
 	int rightInt = static_cast<int>(rightTrigger * 255);
 
-	libevdev_uinput_write_event(uidev.get(), EV_ABS, ABS_HAT2X, leftInt);
-	libevdev_uinput_write_event(uidev.get(), EV_ABS, ABS_HAT2Y, rightInt);
+	libevdev_uinput_write_event(uidev.get(), EV_ABS, ABS_Z, leftInt);
+	libevdev_uinput_write_event(uidev.get(), EV_ABS, ABS_RZ, rightInt);
 }
 
 void GamepadInjector::pressButton(int buttonCode)


### PR DESCRIPTION
## Problem
On Linux, `GamepadInjector` maps LT/RT trigger values to `ABS_HAT2X`/`ABS_HAT2Y`.
These axis codes correspond to a secondary hat switch, not analog triggers.
As a result, trigger presses were sent as real uinput events (SYN_REPORT fired,
timestamps updated on the client side) but no game, browser Gamepad API, or SDL
ever read a value from them — triggers appeared completely dead despite the
connection working correctly for sticks, buttons, and D-pad.

## Fix
Changed the two trigger-related ABS codes to the standard Xbox-controller
trigger axes used by the Linux joystick/xpad convention:
- `ABS_HAT2X` → `ABS_Z`   (left trigger)
- `ABS_HAT2Y` → `ABS_RZ`  (right trigger)

This matches what SDL, the browser Gamepad API, and games with native
controller support (verified with gamepad-tester.com and Wuthering Waves)
expect to read for analog trigger axes.

## Testing
- Built from source on Ubuntu 24.04 (Qt6, libevdev 1.13.1).
- Verified via gamepad-tester.com: LT/RT now report live analog values
  (previously stuck at 0.00 despite the report timestamp updating).
- Confirmed sticks, face buttons, bumpers, and D-pad were unaffected and
  continue to work as before.